### PR TITLE
商品削除機能実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,5 +13,6 @@
 @import "modules/items/new_imageupload";
 @import "modules/items/confirm";
 @import "modules/user";
+@import "modules/users/onsale";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/modules/items/show.scss
+++ b/app/assets/stylesheets/modules/items/show.scss
@@ -68,7 +68,7 @@ a {
 }
 
 .product-contents{
-  height: 2100px;
+  height: 2300px; 
   width: 100%;
   padding-top: 20px;
   position: relative;
@@ -269,6 +269,66 @@ a {
           }
         }
       }
+
+      &__edit-delete-btn-content{
+        height: 250px;
+        width: 700px;
+        background-color: white;
+        margin: 20px auto;
+        position: relative;
+
+        .edit-btn {
+          width: 600px;
+          height: 50px;
+          position: absolute;
+          margin: auto;
+          top: 0;
+          right: 0;
+          bottom: 110px;
+          left: 0;
+          background-color: #FF0000;
+
+          &__text {
+            width: 100%;
+            height: 100%;
+            line-height: 50px;
+            text-align: center;
+            color: white;
+          }
+          .selection {
+            width: 600px;
+            height: 50px;
+            margin: auto;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            line-height: 50px;
+            text-align: center;          
+          }
+          a {
+              .delete-btn {
+                width: 600px;
+              height: 50px;
+              margin: auto;
+              top: 0;
+              right: 0;
+              bottom: 0;
+              left: 0;
+              line-height: 50px;
+              text-align: center;
+              background-color: #AAAAAA;
+              color: white;                
+             }
+          }
+          
+        }
+
+        
+
+      
+
+      }
       &__commentbox{
         height: 400px;
         width: 700px;
@@ -346,14 +406,6 @@ a {
       }
     }
   }
-
-
-
-
-
-
-
-
 
   .appbanner {
     height: 150px;

--- a/app/assets/stylesheets/modules/users/onsale.scss
+++ b/app/assets/stylesheets/modules/users/onsale.scss
@@ -139,7 +139,7 @@
       }
       &__tabTodo {
         width: 700px;
-        height: 243px;
+        height: 76px;
         background-color: hotpink;
         .tabTodo {
           height: 74px;
@@ -176,7 +176,7 @@
         }
 
         .tabContent {
-          height: 190px;
+          height: 81px;
           background-color: #ffffff;
           &__info {
             width: 700px;
@@ -184,10 +184,30 @@
             border-bottom: 1px solid #eee;
           }
           &__lists {
-            width: 636px;
+            width: 700px;
             height: 70px;
             background-color: white;
-            margin: 16px;
+            display: flex;
+
+            &__img {
+
+            }
+
+            &__product-name {
+
+              .onsale-sign {
+                width: 40px;
+                height: 16px;
+                background-color: #0000CD;
+                font-size: 8px;
+                font-weight: bold;
+                color: white;
+                line-height: 16px;
+                text-align: center;
+
+              }
+
+            }
           }
         }
       }

--- a/app/assets/stylesheets/modules/users/onsale.scss
+++ b/app/assets/stylesheets/modules/users/onsale.scss
@@ -145,7 +145,7 @@
           height: 74px;
           background-color: #fff;
           display: flex;
-          &__onsale {
+          .onsale {
             width: 233px;
             height: 74px;
             line-height: 74px;
@@ -153,8 +153,9 @@
             border-top: 2px solid #ea352d;
             color: #333333;
             font-weight: bold;
+            text-decoration: none;
           }
-          &__dealing {
+          .dealing {
             width: 233px;
             height: 74px;
             background-color: #eeeeee;
@@ -163,7 +164,7 @@
             color: #333333;
             font-weight: bold;
           }
-          &__sold {
+          .sold {
             width: 233px;
             height: 74px;
             background-color: #eeeeee;

--- a/app/assets/stylesheets/modules/users/onsale.scss
+++ b/app/assets/stylesheets/modules/users/onsale.scss
@@ -194,6 +194,7 @@
             }
 
             &__product-name {
+              color: #333333;
 
               .onsale-sign {
                 width: 40px;
@@ -204,7 +205,6 @@
                 color: white;
                 line-height: 16px;
                 text-align: center;
-
               }
 
             }

--- a/app/assets/stylesheets/modules/users/onsale.scss
+++ b/app/assets/stylesheets/modules/users/onsale.scss
@@ -1,0 +1,294 @@
+.body {
+  background-color: #f5f5f5;
+  .header {
+    height: 100px;
+    width: auto;
+    background-color: #ffffff;
+    border-bottom: 1px solid;
+    color: #f5f5f5;
+    &__box {
+      height: 100%;
+      width: 65%;
+      margin: 0 auto;
+      padding: 15px 0 0;
+      &__main {
+        height: 40px;
+        width: 100%;
+        display: flex;
+        line-height: 40px;
+        .logo {
+          width: 140px;
+          margin-right: 40px;
+          position: relative;
+          display: flex;
+          align-items: center;
+        }
+        .search__box {
+          display: flex;
+          width: 100%;
+          &__form {
+            width: 100%;
+          }
+          &__btn {
+            display: block;
+            width: 24px;
+            background-color: #3CCACE;
+            padding: 8px;
+          }
+        }
+      }
+      &__sub {
+        font-size: 15px;
+        height: 35px;
+        display: flex;
+        justify-content: space-between;
+        margin: 10px 0;
+        .lists__left {
+          display: flex;
+          line-height: 35px;
+          .category {
+            margin-left: 10px;
+            color: black;
+          }
+          .brand {
+            margin-left: 50px;
+            color: black;
+          }
+        }
+        .lists__right {
+          display: flex;
+          line-height: 35px;
+          .like__list {
+            margin-right: 14px;
+            color: black;
+          }
+          .info__list {
+            margin-right: 14px;
+            color: black;
+          }
+          .todo__list {
+            margin-right: 14px;
+            color: black;
+          }
+          .mypage {
+            color: black;
+          }
+        }
+      }
+    }
+  }
+  
+  
+  .nav {
+    width: auto;
+    height: 49px;
+    background-color: #ffffff;
+    &__itemscope {
+      display: flex;
+      padding: 16px 0;
+      margin: 0 auto 0 auto;
+      width: 1020px;
+      &__itemtype {
+        display: flex;
+        .navgation {
+          text-decoration: none;
+          color: #333333;
+        }
+      }
+    }
+  }
+  .main {
+    width: auto;
+    height: 1292px;
+    background-color: #f5f5f5;
+    display: flex;
+    margin: 40px 210px 0 210px;
+    &__left {
+      background-color: #ffffff;
+      width: 280px;
+      margin-right: 40px;
+      height: 1104px;
+      &__nav {
+        .nav__lists {
+          &__list {
+            width: 248px;
+            height: 15px;
+            border-bottom: 1px solid #eee;
+            padding: 16px;
+            .moji {
+              width: 280px;
+              height: 48px;
+              font-weight: 600;
+              text-decoration: none;
+              color: #333;
+            }
+          }
+        }
+      }
+    }
+    &__right {
+      height: 865px;
+      width: 700px;
+      &__title {
+        width: 660px;
+        height: 50px;
+        font-weight: bold;
+        
+        padding: 20px;
+        background-color: #FAFAFA;
+      }
+      &__tabTodo {
+        width: 700px;
+        height: 243px;
+        background-color: hotpink;
+        .tabTodo {
+          height: 74px;
+          background-color: #fff;
+          display: flex;
+          &__onsale {
+            width: 233px;
+            height: 74px;
+            line-height: 74px;
+            text-align: center;
+            border-top: 2px solid #ea352d;
+            color: #333333;
+            font-weight: bold;
+          }
+          &__dealing {
+            width: 233px;
+            height: 74px;
+            background-color: #eeeeee;
+            line-height: 74px;
+            text-align: center;
+            color: #333333;
+            font-weight: bold;
+          }
+          &__sold {
+            width: 233px;
+            height: 74px;
+            background-color: #eeeeee;
+            line-height: 74px;
+            text-align: center;
+            color: #333333;
+            font-weight: bold;
+          }
+        }
+
+        .tabContent {
+          height: 190px;
+          background-color: #ffffff;
+          &__info {
+            width: 700px;
+            height: 81px;
+            border-bottom: 1px solid #eee;
+          }
+          &__lists {
+            width: 636px;
+            height: 70px;
+            background-color: white;
+            margin: 16px;
+          }
+        }
+      }
+    }
+  }
+
+  .appbanner {
+    height: 150px;
+    width: auto;
+    padding: 100px 40px;
+    background-image: url("/material/pict/bg-appBanner-pict.jpg");
+    background-size: cover;
+    background-position: center;
+    &__inner {
+      color: white;
+      text-align: center;
+      .inner__title {
+        font-size: 24px;
+        text-shadow: 0 0 5px rgba(0,0,0,0.4);
+        font-weight: bold;
+      }
+      .inner__text {
+        font-size: 35px;
+        text-shadow: 0 0 5px rgba(0,0,0,0.4)
+      }
+      .inner__btn {
+        height: 70px;
+        .abtn {
+          height: 100%;
+          width:  auto;
+        }
+        .abtn:hover {
+          opacity: 0.5 ;
+        }  
+        .gbtn {
+          height: 100%;
+          width:  auto;
+          margin-left: 50px;
+          transform: scale(1.45);
+        }
+        .gbtn:hover {
+          opacity: 0.5 ;
+        }
+      }
+    }
+  }
+  .footer {
+    height: 230px;
+    padding: 60px 0;
+    background-color: #333;
+    &__contents {
+      padding: 0 350px;
+      display: flex;
+      justify-content: space-around;
+      .content {
+        .title {
+          margin-bottom: 23px;
+          font-weight: bold;
+          color: white;
+        }
+        .lists {
+          text-align: center;
+          display: block;
+          .list {
+            font-size: 10px;
+            margin-top: 15px;
+            color: white;
+          }
+        }
+      }
+    }
+    &__logo {
+      width: 160px;
+      height: 46px;
+      margin: 0 auto;
+    }
+    .logo__under {
+      text-align: center;
+      height: 16px;
+      color: #fff;
+
+    }
+  }
+
+  a {
+    .exhibit {
+      width: 85px;
+      padding: 15px;
+      background: #3CCACE;
+      text-align: center;
+      border-radius: 4%;
+      position: fixed;
+      bottom: 32px;
+      right: 32px;
+      .text {
+        margin-bottom: 5px;
+        font-size: 18px;
+        color: #fff;
+      }
+      &__icon {
+        width: 60%;
+      }
+    }
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,9 +53,8 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-    unless item.destroy
-      redirect_to onsale_users_path
-    end
+    redirect_to onsale_users_path
+    redirect_to user_path(user.id) unless item.destroy
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,6 +52,9 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,8 +53,9 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-    item.destroy
-    redirect_to root_path
+    unless item.destroy
+      redirect_to onsale_users_path
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,8 +53,8 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
+    redirect_to user_path(user.id) and return unless item.destroy
     redirect_to onsale_users_path
-    redirect_to user_path(user.id) unless item.destroy
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,5 +6,6 @@ class UsersController < ApplicationController
   end
 
   def onsale
+    @items = Item.all
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,4 +4,7 @@ class UsersController < ApplicationController
 
   def show
   end
+
+  def onsale
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,6 +2,7 @@ class Image < ApplicationRecord
   belongs_to :item
   mount_uploader :image, ImageUploader
 
+
   # # 商品画像のバリデーション
   # validates :image, {presence: true, {length: {maximum: 10}}}
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   has_many :comments
-  has_many :images
+  has_many :images, dependent: :destroy
   belongs_to :user
   belongs_to :category, dependent: :destroy, optional: true
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -20,6 +20,8 @@
         %ul.lists__right
           %li
             = link_to "ログアウト",destroy_user_session_path,method: :delete, class: 'login'
+          %li
+            = link_to "マイページ","/users/#{current_user.id}", class: 'login'
       - else
         %ul.lists__right
           %li

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -21,7 +21,7 @@
           %li
             = link_to "ログアウト",destroy_user_session_path,method: :delete, class: 'login'
           %li
-            = link_to "マイページ","/users/#{current_user.id}", class: 'login'
+            = link_to "マイページ",user_path(current_user.id), class: 'login'
       - else
         %ul.lists__right
           %li

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -104,7 +104,21 @@
               = icon('fa', 'flag',class: 'flag-icon')
             .product-contents__inner__mainbox__links__report__letter
               不適切な商品の通報
-      .product-contents__inner__commentbox
+
+      - if user_signed_in? && current_user.id == @item.user_id
+        .product-contents__inner__edit-delete-btn-content
+          .edit-btn
+            .edit-btn__text
+              商品の編集
+            .selection
+              or
+            -# = link_to "この商品を削除する", item_path(item.id),method: :delete, class: "delete-btn"
+            = link_to item_path(@item.id),method: :delete do
+              .delete-btn
+                この商品を削除する
+                
+              
+      .product-contents__inner__commentbox       
         .product-contents__inner__commentbox__content
         .product-contents__inner__commentbox__warning
           相手のことを考え丁寧なコメントを心がけましょう.

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -112,7 +112,6 @@
               商品の編集
             .selection
               or
-            -# = link_to "この商品を削除する", item_path(item.id),method: :delete, class: "delete-btn"
             = link_to item_path(@item.id),method: :delete do
               .delete-btn
                 この商品を削除する

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -2,7 +2,7 @@
   .header
     .header__box
       .header__box__main
-        = link_to "#" do
+        = link_to root_path do
           = image_tag "/material/logo/logo.png", size: "140x40"
         = form_with url: "#", class: "search__box" do |f|
           = f.text_field :content, class: 'search__box__form', placeholder: ' キーワードから探す'

--- a/app/views/users/onsale.html.haml
+++ b/app/views/users/onsale.html.haml
@@ -116,12 +116,12 @@
         出品した商品
       .main__right__tabTodo
         .tabTodo
-          .tabTodo__onsale
-            出品中
-          .tabTodo__dealing
-            取引中
-          .tabTodo__sold
-            売却済み
+          = link_to "出品中", "", class: 'onsale'
+
+          = link_to "取引中", "", class: 'dealing'
+
+          = link_to "売却済み", "", class: 'sold'
+
         .tabContent
           .tabContent__info
           .tabContent__lists

--- a/app/views/users/onsale.html.haml
+++ b/app/views/users/onsale.html.haml
@@ -194,7 +194,7 @@
     %p.logo__under
       ©︎　FURIMA
 
-  = link_to "#" do
+  = link_to new_item_path do
     .exhibit
       .text
         出品する

--- a/app/views/users/onsale.html.haml
+++ b/app/views/users/onsale.html.haml
@@ -1,0 +1,192 @@
+.body
+  .header
+    .header__box
+      .header__box__main
+        =link_to root_path do
+          = image_tag "/material/logo/logo.png", class: 'logo'
+        = form_with url: "#", class: "search__box" do |f|
+          = f.text_field :content, class: 'search__box__form', placeholder: ' キーワードから探す'
+        =link_to "#" do
+          = image_tag "/material/icon/icon-search 1.png", class: 'search__box__btn'
+      .header__box__sub
+        %ul.lists__left
+          %li
+            = link_to "#",class: "category" do
+              カテゴリー
+          %li
+            = link_to "#",class: "brand" do
+              ブランド
+        %ul.lists__right
+          %li
+            = link_to "#",class: "like__list" do
+              いいね！一覧
+          %li
+            = link_to "#",class: "info__list" do
+              お知らせ
+          %li
+            = link_to "#",class: "todo__list" do
+              やることリスト
+          %li
+            = link_to "#",class: "mypage" do
+              マイページ
+  .nav
+    %ul.nav__itemscope
+      %li.nav__itemscope__itemtype
+        = link_to "#",class: "navgation" do
+          FURIMA
+        .nav__itemscope__itemtype__right
+          　>　
+      %li.nav__itemscope__itemtype2
+        マイページ
+  .main
+    .main__left
+      .main__left__nav
+        .nav__lists
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              マイページ
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              お知らせ
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              やることリスト
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              いいね！一覧
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              出品する
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              出品した商品-出品中
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              出品した商品-取引中
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              出品した商品-売却済み
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              購入した商品-取引中
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              購入した商品-過去の取引
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              ニュース一覧
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              評価一覧
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              ガイド
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              お問い合わせ
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              売上・振込申請
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              ポイント
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              プロフィール
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              発送元・お届け先住所変更
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              支払い方法
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              メール/パスワード
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              本人情報
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              電話番号の確認
+          %li.nav__lists__list
+            =link_to "#",class: "moji" do
+              ログアウト
+    .main__right
+      .main__right__title 
+        出品した商品
+      .main__right__tabTodo
+        .tabTodo
+          .tabTodo__onsale
+            出品中
+          .tabTodo__dealing
+            取引中
+          .tabTodo__sold
+            売却済み
+        .tabContent
+          .tabContent__info
+          .tabContent__lists
+            一覧を見る
+
+  .appbanner
+    .appbanner__inner
+      %h1.inner__title
+        だれでもかんたん、人生を変えるフリマアプリ
+      %p.inner__text
+        今すぐ無料ダウンロード！
+      .inner__btn
+        = link_to "#" do
+          = image_tag "/material/badge/Download_on_the_App_Store_Badge.svg", class: "abtn"
+        = link_to "#" do
+          = image_tag "/material/badge/google-play-badge.png", class: "gbtn"
+  .footer
+    %ul.footer__contents
+      %li.content
+        %h1.title
+          FURIMAについて
+        %ul.lists
+          %li.list
+            = link_to "#", class: "list" do
+              会社概要（運営会社）
+          %li.list
+            = link_to "#", class: "list" do
+              プライバシーポリシー
+          %li.list
+            = link_to "#", class: "list" do
+              FURIMA利用規約
+          %li.list
+            = link_to "#", class: "list" do
+              ポイントに関する特約
+      %li.content
+        %h1.title
+          FURIMAを見る
+        %ul.lists
+          %li.list
+            = link_to "#", class: "list" do
+              カテゴリー一覧
+          %li.list
+            = link_to "#", class: "list" do
+              ブランド一覧
+      %li.content
+        %h1.title
+          ヘルプ＆ガイド
+        %ul.lists
+          %li.list
+            = link_to "#", class: "list" do
+              FURIMAガイド
+          %li.list
+            = link_to "#", class: "list" do
+              FURIMAロゴ利用ガイドライン
+          %li.list
+            = link_to "#", class: "list" do
+              お知らせ
+    .footer__logo
+      =link_to "#" do
+        = image_tag "/material/logo/logo-white.png", width: "160px", height: "46px"
+    %p.logo__under
+      ©︎　FURIMA
+
+  = link_to "#" do
+    .exhibit
+      .text
+        出品する
+      = image_tag  "/material/icon/icon_camera.png", class: "exhibit__icon"

--- a/app/views/users/onsale.html.haml
+++ b/app/views/users/onsale.html.haml
@@ -124,8 +124,17 @@
 
         .tabContent
           .tabContent__info
-          .tabContent__lists
-            一覧を見る
+            - @items.each do |item|
+              - item.images.first(1).each do |image|      
+                - if item.item_purchaser_id.blank?
+                  = link_to item_path(item.id) do
+                    .tabContent__lists
+                      .tabContent__lists__img
+                        = image_tag "#{image.image}", alt: "テスト", size: "150x70"
+                      .tabContent__lists__product-name
+                        = item.item_name
+                        .onsale-sign
+                          出品中
 
   .appbanner
     .appbanner__inner

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -204,7 +204,7 @@
     %p.logo__under
       ©︎　FURIMA
 
-  = link_to "#" do
+  = link_to new_item_path do
     .exhibit
       .text
         出品する

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -58,7 +58,7 @@
             =link_to "#",class: "moji" do
               出品する
           %li.nav__lists__list
-            =link_to "#",class: "moji" do
+            =link_to onsale_users_path,class: "moji" do
               出品した商品-出品中
           %li.nav__lists__list
             =link_to "#",class: "moji" do

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -2,7 +2,7 @@
   .header
     .header__box
       .header__box__main
-        =link_to "#" do
+        =link_to root_path do
           = image_tag "/material/logo/logo.png", class: 'logo'
         = form_with url: "#", class: "search__box" do |f|
           = f.text_field :content, class: 'search__box__form', placeholder: ' キーワードから探す'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Rails.application.routes.draw do
       resources :images, only: [:index,:create]
     end
     resources :users, only: [:show] do
+      collection do
+        get :onsale
+      end
       resources :profile, only: :index
       resources :creditcards, only: :index
       resources :location, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,17 +16,13 @@ Rails.application.routes.draw do
       get :category_children
       get :category_grandchildren
     end
-    resources :users, only: [:show] do
-      collection do
-        get :onsale
-      end
-      resources :profile, only: :index
-      resources :creditcards, only: :index
-      resources :location, only: :index
     resources :comments, only: :create
     resources :images, only: [:index,:create]
   end
   resources :users, only: [:show] do
+    collection do
+      get :onsale
+    end
     resources :profile, only: :index
     resources :creditcards, only: :index
     resources :location, only: :index

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,14 +53,14 @@ ActiveRecord::Schema.define(version: 2020_03_13_041808) do
     t.bigint "user_id"
     t.bigint "item_purchaser_id"
     t.bigint "category_id"
-    t.bigint "brand_id"
+    t.string "brand_name"
     t.string "item_name", null: false
     t.text "description", null: false
     t.string "price", null: false
     t.string "size"
     t.string "condition", null: false
     t.string "shipping_fee_payer", null: false
-    t.string "shipping_location", null: false
+    t.bigint "prefecture_id", null: false
     t.string "shipping_days", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
### **WHAT**
商品削除機能を実装
行った事
①商品の詳細ページで投稿者のみが削除ボタンを表示されるようになっている
→if文を使い、ユーザーIDとカレントユーザーIDがイコールの時のみ、削除ボタンが表示されるようにした。
キャプチャ画像
▽別のユーザーが商品詳細ページをみた場合
https://gyazo.com/456ae25855d7fee5c3a472ae338973be
▽投稿者が商品詳細ページをみた場合
https://gyazo.com/cfaff949dba8e20f0821c2849a902673

②実際に削除が出来る。削除すると紐づく画像データも一緒に削除される
→item.rbにdependent: :destroyと記述することで、itemが削除されたらimageも削除されるようにした。

今は削除した後はrootパスにリダイレクトするように設定しています。

### **WHY**
①勝手に他の人の出品データを削除出来ないようにするため
②商品と画像はテーブルを分けて設計しているので、商品が消えるとそれに付随する画像データも消えるようにする必要があるから