### PR TITLE
住所登録時：建物名のバリデーション削除

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,4 +1,4 @@
 class Location < ApplicationRecord
   belongs_to :user, optional: true
-  validates :family_name, :first_name, :family_name_kana, :first_name_kana, :postal_code, :prefecture, :city, :building_name, :phone_name, presence: true
+  validates :family_name, :first_name, :family_name_kana, :first_name_kana, :postal_code, :prefecture, :city, :phone_name, presence: true
 end

--- a/app/views/devise/registrations/new_location.html.haml
+++ b/app/views/devise/registrations/new_location.html.haml
@@ -43,7 +43,7 @@
           = f.text_field :city, {class:'form-group__input'}
         .form-group
           = f.label :建物名
-          %span.form-group__require 必須
+          %span.form-group__require
           = f.text_field :building_name, {class:'form-group__input'}
         .form__group
           = f.label :電話番号


### PR DESCRIPTION
[what]
住所情報登録時の「建物名」のバリデーションを削除
[why]
建物名記載不要のユーザーも存在するから。