### PR TITLE
新規登録画面にてパスワード確認用の入力欄を追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   validates :user_family_name, :user_first_name, :user_family_name_kana, :user_first_name_kana,:birth, presence: true
   validates :email, uniqueness: true, format: { with: /\A([a-zA-Z0-9])+([a-zA-Z0-9\._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9\._-]+)+\z/ }
   validates :user_family_name, :user_first_name, :user_family_name_kana, :user_first_name_kana, format: { with: /\A[ぁ-んァ-ヶー一-龠]+\z/ }
+  validates :password, confirmation: true
+
 
   has_many :items, dependent: :destroy
   has_many :comments

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -25,13 +25,11 @@
           = f.label :パスワード
           %span.form-group__require 必須
           = f.password_field :password,{autocomplete: "new-password",placeholder: "7文字以上の半角英数字",class:'form-group__input',id:"password"}
+        .form-group
+          = f.label :確認用パスワード
+          %span.form-group__require 必須
+          = f.password_field :password_confirmation,{autocomplete: "new-password",placeholder: "7文字以上の半角英数字",class:'form-group__input',id:"password"}
           %p.form-group__info ※ 英字と数字の両方を含めて設定してください
-          .form-password-revelation-toggle
-            .checkbox-default
-              %input#reveal_password{type: "checkbox",class:"icon-check"}
-              %label{for: "reveal_password"} パスワードを表示する
-            .form-password-revelation-revealed-password-container
-              %span.form-password-revelation-revealed-password
         .form-group
           %label.form-group-text-title 本人確認
           %p.form-group__info 


### PR DESCRIPTION
### **WHAT**
新規ユーザー登録時にて、セキュリティ強化のため確認用にパスワードを２回入力してもらう仕様へ変更。
devise/registration/new.html.haml にpassword confirmationのフォームを追加し、
user.rbに以下を追加した。
validates :password, confirmation: true

### **WHY**
最終課題の提出にて修正の指摘をいただいたため
https://github.com/Yoshi101-web/freemarket_sample_70g/issues/77
