### PR TITLE
機能していなかった「もどる」ボタンへリンク設定

### DIFF
--- a/app/assets/stylesheets/modules/items/edit.scss
+++ b/app/assets/stylesheets/modules/items/edit.scss
@@ -600,7 +600,7 @@
           cursor: pointer;
         }
 
-        .return-btn {
+        .edit-return-btn {
           background-color: #DDDDDD;
           font-weight: bold;
           width: 360px;

--- a/app/assets/stylesheets/modules/items/new.scss
+++ b/app/assets/stylesheets/modules/items/new.scss
@@ -563,10 +563,9 @@
           outline: none;
           border-style: none;
           margin: 20px 170px;
-          cursor: pointer;
+          cursor: pointer; 
         }
-
-        .return-btn {
+        .new-return-btn {
           background-color: #DDDDDD;
           font-weight: bold;
           width: 360px;
@@ -577,6 +576,8 @@
           margin: 5px 170px;
           cursor: pointer;
         }
+
+        
 
         .terms-info-box {
           font-size: 12px;

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -33,4 +33,4 @@
 %h3 Cancel my account
 %p
   Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -164,7 +164,8 @@
 
           = f.submit "再出品する", class: "sell-btn"
 
-          %input.return-btn{type: "button", value: "もどる"}
+          = link_to :back do
+            %input.edit-return-btn{type: "button", value: "もどる"}
 
           .terms-info-box
             %p.tems-info-description 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -137,7 +137,8 @@
 
           = f.submit "出品する", class: "sell-btn"
 
-          %input.return-btn{type: "button", value: "もどる"}
+          = link_to :back do
+            %input.new-return-btn{type: "button", value: "もどる"}
 
           .terms-info-box
             %p.tems-info-description 


### PR DESCRIPTION
### **WHAT**
items>new
items>edit
上記2つのビューの「もどる」ボタンを押しても機能していなかったのを
「= link_to :back do」で前のページに戻るようにした。

### **WHY**
対応の抜け漏れチェックのため